### PR TITLE
Fix derp in commit protocol

### DIFF
--- a/txn_proto2_impl.h
+++ b/txn_proto2_impl.h
@@ -977,7 +977,7 @@ public:
     INVARIANT(!this->is_snapshot());
 
     COMPILER_MEMORY_FENCE;
-    u_.commit_epoch = this->rcu_guard_->guard()->tick();
+    u_.commit_epoch = ticker::s_instance.global_current_tick();
     COMPILER_MEMORY_FENCE;
 
     tid_t ret = ctx.last_commit_tid_;


### PR DESCRIPTION
I took over the old guard()->tick() from the old commit protocol
w/o noticing that it was NOT in fact a read of the true global
tick. Thank you invariants for disabusing me.

Now tests pass with invariants on.
